### PR TITLE
Fix #10. Allow gutterView settings

### DIFF
--- a/lib/syntax-settings.coffee
+++ b/lib/syntax-settings.coffee
@@ -23,6 +23,9 @@ module.exports =
       'fontFamily', 'fontSize', 'invisibles', 'placeholderText',
       'showIndentGuide', 'showInvisibles', 'softWrap'
     ]
+    'gutterViewSettings': [
+      'showLineNumbers'
+    ]
   }
 
   buffers: []
@@ -67,6 +70,7 @@ module.exports =
   _setSyntaxSettings: (editorView, editor, languageSettings) ->
     @_loopAndSetSettings(editor, languageSettings, 'editorSettings')
     @_loopAndSetSettings(editorView, languageSettings, 'editorViewSettings')
+    @_loopAndSetSettings(editorView.gutter, languageSettings, 'gutterViewSettings')
 
   _loopAndSetSettings: (object, settings, name) ->
     objectSettings = settings[name]


### PR DESCRIPTION
This will allow the usage of any gutterView setting. Although it's not listed in the API documentation, the recent open sourcing of atom has helped us find how you can do this.

https://github.com/atom/atom/blob/master/src/gutter-view.coffee
